### PR TITLE
Fix issues with bootstrap dropdown

### DIFF
--- a/.angular-cli.json
+++ b/.angular-cli.json
@@ -19,7 +19,6 @@
       "testTsconfig": "tsconfig.spec.json",
       "prefix": "app",
       "styles": [
-        "../node_modules/font-awesome/scss/font-awesome.scss",
         "../node_modules/bootstrap/scss/bootstrap.scss",
         "styles.scss"
       ],

--- a/.angular-cli.json
+++ b/.angular-cli.json
@@ -19,12 +19,11 @@
       "testTsconfig": "tsconfig.spec.json",
       "prefix": "app",
       "styles": [
-        "../node_modules/bootstrap/scss/bootstrap.scss",
         "styles.scss"
       ],
       "scripts": [
         "../node_modules/jquery/dist/jquery.min.js",
-        "../node_modules/popper.js/dist/popper.min.js",
+        "../node_modules/popper.js/dist/umd/popper.min.js",
         "../node_modules/bootstrap/dist/js/bootstrap.min.js"
       ],
       "environmentSource": "environments/environment.ts",

--- a/package-lock.json
+++ b/package-lock.json
@@ -210,6 +210,32 @@
         "tslib": "1.9.2"
       }
     },
+    "@fortawesome/fontawesome": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome/-/fontawesome-1.1.8.tgz",
+      "integrity": "sha512-c0/MtkPVT0fmiFcCyYoPjkG9PkMOvfrZw2+0BaJ+Rh6UEcK1AR/LaRgrHHjUkbAbs9LXxQJhFS8CJ4uSnK2+JA==",
+      "requires": {
+        "@fortawesome/fontawesome-common-types": "0.1.7"
+      }
+    },
+    "@fortawesome/fontawesome-common-types": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.1.7.tgz",
+      "integrity": "sha512-ego8jRVSHfq/iq4KRZJKQeUAdi3ZjGNrqw4oPN3fNdvTBnLCSntwVCnc37bsAJP9UB8MhrTfPnZYxkv2vpS4pg=="
+    },
+    "@fortawesome/fontawesome-free-solid": {
+      "version": "5.0.13",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free-solid/-/fontawesome-free-solid-5.0.13.tgz",
+      "integrity": "sha512-b+krVnqkdDt52Yfev0x0ZZgtxBQsLw00Zfa3uaVWIDzpNZVtrEXuxldUSUaN/ihgGhSNi8VpvDAdNPVgCKOSxw==",
+      "requires": {
+        "@fortawesome/fontawesome-common-types": "0.1.7"
+      }
+    },
+    "@fortawesome/fontawesome-free-webfonts": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free-webfonts/-/fontawesome-free-webfonts-1.0.9.tgz",
+      "integrity": "sha512-nLgl6b6a+tXaoJJnSRw0hjN8cWM/Q5DhxKAwI9Xr0AiC43lQ2F98vQ1KLA6kw5OoYeAyisGGqmlwtBj0WqOI5Q=="
+    },
     "@ngtools/json-schema": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@ngtools/json-schema/-/json-schema-1.1.0.tgz",
@@ -3691,11 +3717,6 @@
           }
         }
       }
-    },
-    "font-awesome": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/font-awesome/-/font-awesome-4.7.0.tgz",
-      "integrity": "sha1-j6jPBBGhoxr9B7BtKQK7n8gVoTM="
     },
     "for-in": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -21,9 +21,11 @@
     "@angular/platform-browser": "^5.2.0",
     "@angular/platform-browser-dynamic": "^5.2.0",
     "@angular/router": "^5.2.0",
+    "@fortawesome/fontawesome": "^1.1.8",
+    "@fortawesome/fontawesome-free-solid": "^5.0.13",
+    "@fortawesome/fontawesome-free-webfonts": "^1.0.9",
     "bootstrap": "^4.1.1",
     "core-js": "^2.4.1",
-    "font-awesome": "^4.7.0",
     "jquery": "^3.3.1",
     "popper.js": "^1.14.3",
     "rxjs": "^5.5.6",
@@ -49,7 +51,6 @@
     "tslint": "~5.9.1",
     "typescript": "~2.5.3",
     "bootstrap": "^4.1.1",
-    "font-awesome": "^4.7.0",
     "jquery": "^3.3.1",
     "popper.js": "^1.14.3"
   }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,5 +1,9 @@
 /* You can add global styles to this file, and also import other style files */
 /* You can add global styles to this file, and also import other style files */
+$fa-font-path: "../node_modules/@fortawesome/fontawesome-free-webfonts/webfonts";
+@import "../node_modules/@fortawesome/fontawesome-free-webfonts/scss/fontawesome.scss";
+@import "../node_modules/@fortawesome/fontawesome-free-webfonts/scss/fa-solid.scss";
+
 body{
 	font-family: 'Raleway', sans-serif;
 }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -3,6 +3,7 @@
 $fa-font-path: "../node_modules/@fortawesome/fontawesome-free-webfonts/webfonts";
 @import "../node_modules/@fortawesome/fontawesome-free-webfonts/scss/fontawesome.scss";
 @import "../node_modules/@fortawesome/fontawesome-free-webfonts/scss/fa-solid.scss";
+@import "~bootstrap/scss/bootstrap.scss";
 
 body{
 	font-family: 'Raleway', sans-serif;


### PR DESCRIPTION
Changes  :  
1) fixed the issue with the three dots not showing up properly (this was becuase of a font awesome version upgrade)

2) fixed the issue with bootstrap dropdowns not opening up in the hamburger menu in mobile mode and on click of the  ellipsis .
   Solution : This was an issue with popper js . update done in angular cli file . 
instead of reffering ../node_modules/popper.js/dist/popper.min.js  , reffered ../node_modules/popper.js/dist/umd/popper.min.js